### PR TITLE
Change README to follow documentation standard

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,19 +1,44 @@
 # Development Container
 
-[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Container&message=Open&color=blue&logo=visualstudiocode)](https://rickos99.github.io/js-UrlRedirect/?redirect=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/D7017E/Rock-Paper-Scissors)
+This repository includes configuration for a local development container based on [Visual Studio Code Remote - Containers](https://aka.ms/vscode-remote/containers). This allows you to open the repository in a container running on your local machine, and take advantage of the tools and extensions installed in the container.
 
-This repository includes configuration for a local development container or using [GitHub Codespaces](https://github.com/features/codespaces).
-
-## Quick start - local
-
-If you already have VS Code and Docker installed, you can click the badge above or [here](https://rickos99.github.io/js-UrlRedirect/?redirect=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/D7017E/Rock-Paper-Scissors) to get started. Clicking these links will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
+## Usage
 
 1. Install Docker Desktop or Docker for Linux on your local machine. (See [docs](https://aka.ms/vscode-remote/containers/getting-started) for additional details.)
 
 2. Install [Visual Studio Code](https://code.visualstudio.com/) and the [Dev Containers](https://aka.ms/vscode-remote/download/containers) extension.
 
-3. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Remote Containers: Clone Repository in Container Volume...**.
+3. Clone this repository to your local machine and open it in Visual Studio Code.
 
-4. Type `https://github.com/D7017E/Rock-Paper-Scissors` (or a branch or PR URL) in the input box and press <kbd>Enter</kbd>.
+4. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Dev Containers: Open Folder in Container...**.  
+*NOTE: This step may take a while the first time you run it.*
 
-:warning: **Note:** When the dev contaner is removed, all changes not commited will be permanently deleted too. To avoid this, before step 3, clone the repository onto local filesystem and open in it in VS Code. Then, in step 3 select **Remote Containers: Open Folder in Container** and all changes made in the devcontainer are made on the local filesystem and not the devcontainer volume.
+### Improved disk I/O
+
+For better disk I/O on macOS and Windows, use the **Dev Containers: Clone Repository in Container Volume...** command to create a container with a Docker volume attached. IMPORTANT: This will not preserve any local changes not committed and pushed to the remote repository when the container is deleted.
+
+## Common issues
+
+### Cannot start the devlopement container
+
+Make sure that Docker Desktop is running, and that you have the latest version of the [Dev Containers](https://aka.ms/vscode-remote/download/containers) extension installed.
+
+### Unable to build the container image
+
+#### Alternative 1: Rebuild the container image
+
+Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Dev Containers: Rebuild Without Cache and Reopen in Container**.
+
+This will rebuild the container image without using the cache and then reopen the folder in the container.
+
+#### Alternative 2: Manually rebuild the container image
+
+1. Open a terminal in the cloned repository folder.
+
+2. Run the following command to build the container image:
+
+```bash
+cd .devcontainer && docker build .
+```
+
+3. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Dev Containers: Open Folder in Container...**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to the project
+
+This guide is intended for developers who want to contribute to the project. It contains information about how to set up the development environment and how to run and/or debug the application in the provided [VS Code dev container](./.devcontainer/README.md).
+
+## Table of contents
+
+- [Contributing to the project](#contributing-to-the-project)
+  - [Table of contents](#table-of-contents)
+  - [Getting started](#getting-started)
+  - [Development](#development)
+    - [Environment setup](#environment-setup)
+    - [Python modules](#python-modules)
+    - [Documentation](#documentation)
+      - [Official documentation](#official-documentation)
+    - [Debug](#debug)
+
+## Getting started
+
+Contributions are made to this repo via Issues and Pull Requests (PRs). Before you open a new issue or PR, please make sure that you have searched for existing Issues and PRs before creating your own.
+
+## Development
+
+### Environment setup
+
+Follow the steps in the [development container](./.devcontainer/README.md) to set up the development container. The following sections assume that you have set up and are running the development container.
+
+### Python modules
+
+In this project, the Pepper robot is configured as read-only and you are unable to install new Python modules via PyPI (PIP). Therefore you should not modify the `requirements.txt` file.
+
+However, if you need to install a new development dependency, you can add it to the `requirements-dev.txt` file. This file is used to install the development dependencies in the development container and will not be available on the robot.
+
+### Documentation
+
+The documentation for this project is generated using [Sphinx](https://www.sphinx-doc.org/en/master/). To generate the documentation, change directory to `docs/` and run:
+
+```bash
+make html
+```
+
+The generated documentation is then available in the `docs/build/html/` folder. To view the documentation, open the `index.html` file in a browser.
+
+#### Official documentation
+
+The official documentation for the robot and the NAOqi SDK can be found at [doc.aldebaran.com](http://doc.aldebaran.com/2-5/index.html).
+
+### Debug
+
+To start a debug session, follow the steps below:
+
+1. Open the python file you want to debug.
+2. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Debug: Select and Start Debugging**. Next, select **Python: Debug File** in the dropdown list to start debugging.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,50 @@
 # Rock-Paper-Scissors
 
-This is a repo for the rock-paper-scissor module.
+This is a repo for the rock-paper-scissor module to make the robot [Pepper](https://www.aldebaran.com/en/pepper) play a game of rock paper scissors with a human opponent. The module is written in Python 2.7 and uses the [NAOqi python SDK](http://doc.aldebaran.com/2-5/dev/python/) to communicate with the robot.
+
+## Tools / Installation
+
+The following tools are required to install and run the application:
+
+- SSH client ([PuTTY](https://www.putty.org/), [OpenSSH](https://www.openssh.com/), etc.)
+- SFTP client ([FileZilla](https://filezilla-project.org/), [OpenSSH](https://www.openssh.com/), etc.)
+
+These tools are used to connect to the robot and transfer the application files to the robot. Instructions are provided below on how to install the application on the robot. This section will not cover how to run the application on your local machine.
+
+### Installation
+
+To install the application, follow these steps:
+
+1. Connect to the robot using SFTP.
+
+2. Transfer the `src` folder to the robot using the path `~/rps/src`.
+
+3. Transfer the `www/rps` folder to the robot using the path `~/.local/share/ota/rps`.
 
 ## Usage
 
-If you are not using the development container, you will need to install the required dependencies first. Otherwise you can skip to step 4.
+1. Connect to the robot using SSH.
 
-**Step 1.** Install [Python 2.7](https://www.python.org/download/releases/2.7/).
+2. Run the below command to start the application. Replace `<LANGUAGE>` with the language you want to use: `English` or `Swedish`.
 
-**Step 2.** Start by installing the required modules
+    ```bash
+    python ./rps/src/app.py <LANGUAGE>
+    ```
 
-```bash
-pip install -r requirements.txt
-```
+    Pepper will then start the application and wait for a human opponent to join the game.
 
-**Step 3.** Download and extract the [Pepper SDK](PepperSDK.md).
+### Examples
 
-**Step 4.** Upload the [`www/rps`](./www/rps/) folder to pepper using path `/data/home/nao/.local/share/ota/`, e.g. `/data/home/nao/.local/share/ota/rps/image_feed.html`. The easiest way to complete the upload is to use sftp, see [ssh.com](https://www.ssh.com/academy/ssh/sftp) for more information.
-
-**Step 5.** Start the application with `python ./src/app.py`.
-
-## Capture images
-
-To capture images, you need to run the `capture.py` script. This script will capture images from the robot's camera and save them on the computer the script is running on. If you are using the dev container and not already in the project root, navigate to `/workspaces/Rock-Paper-Scissors`. Next run
+Start the application in English:
 
 ```bash
-python ./src/ai/capture_image.py [name_of_image.jpg]
+python ./rps/src/app.py English
 ```
 
-If only an image name is provided, the image will be saved in the current path. If a path is provided, the image will be saved in the specified path.
+## Contributing
 
-## Development
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to set up the development environment on your local machine and how to suggest changes or enhancements to the project.
 
-### Dependencies
+## License
 
-All dependencies are managed by pip and are listed in the `requirements.txt` and `requirements-dev.txt` file. The development dependencies are only required if you want to make changes to the code. To install the dependencies, including the development dependencies, run:
-
-```bash
-pip install -r requirements.txt -r requirements-dev.txt
-```
-
-The `requirements.txt` file contains the dependencies required to launch the application and the `requirements-dev.txt` file contains tools used during development.
-
-If a new dependency is added, make sure to update the correct requirement file with name and version of the new dependency. The same applies when removing a dependency. To automatically update the requirements file `requirements.txt`, run:
-
-```bash
-pipreqs
-```
-
-### Development Container _(optional)_
-
-This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces development container.
-
-- For [Dev Containers](https://aka.ms/vscode-remote/download/containers), use the **Dev Containers: Clone Repository in Container Volume...** command which creates a Docker volume for better disk I/O on macOS and Windows.
-  - If you already have VS Code and Docker installed, you can also click [here](vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/D7017E/Rock-Paper-Scissors) to get started. This will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
-- For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
-
-See the [development container README](.devcontainer/README.md) for more information.
-
-When communicating with the host machine via network, e.g. to access local instance of [rps server](https://github.com/d7017e/rps_server), please use the following address: `host.docker.internal`. To make a http request to a local rps server from the devcontainer, use the address: `http://host.docker.internal:5000`. Change the port number if you are using a different port.
-
-### Documentation
-
-The documentation is generated using [Sphinx](https://www.sphinx-doc.org/en/master/). To generate the documentation, change directory to `docs/` and run:
-
-```bash
-make html
-```
-
-The generated documentation is then available in the `docs/build/html/` folder. To view the documentation, open the `index.html` file in a browser.
-
-### Debug
-
-To start a debug session, the [debugpy](https://pypi.org/project/debugpy/) module must be installed in the environment, see [Dependencies](#dependencies).
-
-#### Using VS Code
-
-1. Open the python file you want to debug.
-2. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Debug: Select and Start Debugging**. Next, select **Python: Debug File** in the dropdown list to start debugging.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Moved development-specific details and instructions from `README.md` to a new `CONTRIBUTING.md` file. Also, the content of the `README.md` has been rewritten to make it easier to read and to point.

Changed instructions in `.devcontainer/README.md` to the more safe workflow.